### PR TITLE
docs: OctoGear curator guide, audit distinction, and welcome page upd…

### DIFF
--- a/docs/Intro/01.welcome-to-untangled.mdx
+++ b/docs/Intro/01.welcome-to-untangled.mdx
@@ -16,6 +16,7 @@ Untangled Finance builds and advises on yield strategies through our in-house cr
 We designed and built: 
 - **OctoVault**, a cross-chain vault and risk management infrastructure that enables automated, institutional-grade structured yield strategies across both RWAs and crypto-native assets.
 - **OctoLend**, a Stellar-based curated lending market with collateral delegation that facilitates institutional liquidity for bluechip crypto-native and RWAs collaterals.
+- **OctoGear**, a leveraged trading layer for prediction markets — one Prime Account to trade, borrow, and earn across Polymarket and Hyperliquid.
 
 ### Superior risk monitoring
 We transform data on risk, security, and protocol incentives, using both quantitative and qualitative methods, into powerful analytics, real-time monitoring, and risk oracles—delivering custom risk data via zero-knowledge proof.
@@ -39,8 +40,34 @@ Backed by **Fasanara Capital**, a leading institutional asset manager and fintec
 
   <Link className={styles.card} to="https://stellar.untangled.finance/loop" target="_blank" rel="noopener noreferrer">
     <h3>Untangled Loop (Stellar)</h3>
-    <p> Execution adapter to create, manage, and monitor synthetic perpetual positions on Stellar.</p>
+    <p>Execution adapter to create, manage, and monitor synthetic perpetual positions on Stellar.</p>
   </Link>
+
+  <Link className={styles.card} to="https://octogear.untangled.finance" target="_blank" rel="noopener noreferrer">
+    <h3>OctoGear</h3>
+    <p>Trade prediction markets, borrow against collateral, and earn yield — all from one Prime Account.</p>
+  </Link>
+
+</div>
+
+## OctoGear Docs
+
+<div className={styles.cardGrid}>
+
+<Link className={styles.card} to="/docs/OctoGear/intro">
+  <h3>About OctoGear</h3>
+  <p>Leveraged trading for prediction markets — trade, borrow, and earn with one Prime Account.</p>
+</Link>
+
+<Link className={styles.card} to="/docs/OctoGear/guides/create-account">
+  <h3>Get Started</h3>
+  <p>Create a Prime Account and fund it to start trading on Polymarket and Hyperliquid.</p>
+</Link>
+
+<Link className={styles.card} to="/docs/OctoGear/curator/curator-overview">
+  <h3>Curator Guide</h3>
+  <p>Deploy and manage a lending market on OctoGear — configure risk parameters and earn fees.</p>
+</Link>
 
 </div>
 

--- a/docs/OctoGear/curator/_category_.json
+++ b/docs/OctoGear/curator/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Curator Guide",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "How to deploy and manage an OctoGear lending market as a curator — configure risk parameters, launch strategies, and earn fees."
+  }
+}

--- a/docs/OctoGear/curator/add-strategies.md
+++ b/docs/OctoGear/curator/add-strategies.md
@@ -1,0 +1,69 @@
+---
+id: add-strategies
+title: Add Strategies (Credit Managers)
+sidebar_label: 3. Add Strategies
+sidebar_position: 4
+description: How to attach borrowing strategies to an OctoGear market — leverage parameters, liquidation economics, and position limits.
+---
+
+# Add Strategies (Credit Managers)
+
+A **Strategy** (technically a "Credit Manager") is the credit product offered to borrowers. While the Pool holds the liquidity, the Strategy defines *how that liquidity can be used*.
+
+Examples:
+- "USDC.e Conservative" — low risk, high LTV, whitelisted stablecoins only
+- "PM Leveraged Trading" — prediction market collateral, moderate LTV, Polymarket adapter
+
+You can attach multiple strategies to a single pool to segment risk and offer different terms for different borrower profiles.
+
+## How to add a strategy
+
+### Step 1 — Select a strategy bundle
+
+In the curation interface, open the **New Strategy** tab and search for the collateral token you want to support (e.g. cUSDC, YES tokens). Strategy bundles are pre-configured recipes — selecting one automatically configures the smart contract adapters needed to enable leverage for that asset.
+
+If no bundle exists for your target token, contact the OctoGear team to request one.
+
+### Step 2 — Set leverage parameters
+
+**Liquidation Threshold (LT)**
+
+The primary lever for risk management. Sets the maximum leverage borrowers can take.
+
+- Formula: `Max Leverage = 1 / (1 - LT)`
+- Example: LT 90% → 10x leverage; LT 80% → 5x leverage
+
+**Interest Fee (revenue)**
+
+The percentage of borrowing interest captured as curator revenue, split 50/50 with the Protocol DAO by default. This is charged *on top* of the base rate — if the base rate is 5% and your fee is 20%, borrowers pay 6%. The Interest Fee is fixed at deployment; changing it later requires a new Credit Manager.
+
+### Step 3 — Liquidation economics
+
+These parameters incentivise third-party liquidators to keep the protocol solvent.
+
+| Parameter | Description |
+|---|---|
+| **Liquidation Premium** | Percentage of collateral paid to the liquidator as a reward |
+| **Liquidation Fee** | Percentage of collateral taken by the Protocol (Curator + DAO) during liquidation |
+
+Set the premium high enough to cover slippage, gas, and oracle uncertainty. If liquidators are not incentivised to execute, the system will accumulate bad debt.
+
+### Step 4 — Position limits
+
+| Parameter | Description |
+|---|---|
+| **Min Debt** | Must be high enough to cover liquidator gas costs |
+| **Max Debt** | Limits single-account exposure |
+| **Max Enabled Tokens** | Maximum number of different collateral tokens a user can hold simultaneously (keep at 1 for efficiency) |
+
+**Technical constraint:** `maxDebt / minDebt ≤ 100 / maxEnabledTokens`
+
+Example: 4 tokens → ratio is 25 → if Min Debt = $10,000, Max Debt ≤ $250,000.
+
+### Step 5 — Lifecycle (optional)
+
+For fixed-term products (e.g. a "Season 1" pool), configure an expiration date. After this date, all accounts can be liquidated regardless of health factor, and new borrowing is disabled. You can set separate liquidation penalties for the expired period.
+
+### Step 6 — Review and deploy
+
+Review the configuration summary in the interface, then proceed to [Execute Onchain](./execute-onchain).

--- a/docs/OctoGear/curator/claim-fees.md
+++ b/docs/OctoGear/curator/claim-fees.md
@@ -1,0 +1,36 @@
+---
+id: claim-fees
+title: Claim Accrued Fees
+sidebar_label: 5. Claim Fees
+sidebar_position: 6
+description: How curators claim accrued interest and liquidation fees from their OctoGear markets.
+---
+
+# Claim Accrued Fees
+
+Unclaimed fees sit in the protocol and act as a first line of defence against bad debt. If a liquidation results in a loss, the protocol can burn accrued fees to cover the deficit before touching the liquidity pool. Claim fees periodically to realise your revenue.
+
+## Steps
+
+### Step 1 — Initiate a proposal
+
+In the curation interface:
+
+1. Click **New GIP** (or select an existing draft).
+2. Select the **Market** you want to claim fees from.
+
+### Step 2 — Add the distribution action
+
+1. Go to the **Details** tab of the market.
+2. Locate the **Accrued Fees** section.
+3. Click **Distribute** — this adds a fee distribution transaction to your GIP batch. It does not execute immediately.
+
+### Step 3 — Execute via timelock
+
+Like all governance actions, claiming fees follows the standard proposal lifecycle:
+
+1. **Finalize** the GIP.
+2. **Queue** the transaction in your Safe (starts the 24h timelock).
+3. **Execute** the transaction after the timelock expires.
+
+Once executed, the funds appear in your **Fee Collector** wallet.

--- a/docs/OctoGear/curator/create-configurator.md
+++ b/docs/OctoGear/curator/create-configurator.md
@@ -1,0 +1,53 @@
+---
+id: create-configurator
+title: Create a Market Configurator
+sidebar_label: 1. Create a Configurator
+sidebar_position: 2
+description: How to deploy a Market Configurator — the root admin contract for your OctoGear lending market.
+---
+
+# Create a Market Configurator
+
+The **Market Configurator** is the central administration contract for your lending business. It is the root permission node from which you deploy markets, adjust risk parameters, and manage fee distribution. Deploy it once per blockchain network.
+
+## Before you start
+
+**Drafting vs. signing are separate steps.** The OctoGear curation interface is a *drafting tool*, not a signing terminal.
+
+- **Drafting** — connect any standard wallet to the UI to configure parameters and generate transaction files.
+- **Signing** — execution happens in a Gnosis Safe. Operations teams can draft complex updates without requiring signers to connect high-security wallets to the web interface.
+
+**Using an institutional MPC wallet (Fordefi, Fireblocks, etc.)?** MPC wallets often lack direct support for batch transaction builders. Deploy a 1/1 Safe multisig with your MPC address as the sole signer — this acts as a compatibility layer while retaining MPC custody.
+
+## Deployment steps
+
+### Step 1 — Define governance roles
+
+In the OctoGear curation interface, set the following addresses:
+
+| Role | Function | Recommendation |
+|---|---|---|
+| **Admin** | Primary governance. Can modify all parameters subject to a 24h timelock. | Main Safe multisig (or 1/1 Safe for MPC users) |
+| **Emergency Admin** | Crisis response. Limited emergency actions that bypass the timelock. | Separate security multisig or hardware wallet |
+| **Fee Collector** | Revenue destination. Receives all accrued interest and liquidation fees. | Ops wallet or multisig |
+
+Select **SAFE** as the transaction format to generate a compatible JSON file.
+
+### Step 2 — Execute in Safe
+
+1. Navigate to your **Gnosis Safe** (using the Admin wallet defined in Step 1).
+2. Open the **Transaction Builder** app.
+3. Upload the generated JSON file.
+4. Review the transaction details and execute.
+
+### Step 3 — Sync the interface
+
+Once the transaction is confirmed onchain:
+
+1. Navigate to the **Curators** page in the OctoGear curation interface.
+2. Click **Sync** on the relevant chain.
+3. Wait for the sync to complete — your new Market Configurator will appear in the dashboard.
+
+## Next steps
+
+With the Market Configurator deployed, the infrastructure is ready to launch your first lending market. Continue to [Create a Market](./create-market).

--- a/docs/OctoGear/curator/create-market.md
+++ b/docs/OctoGear/curator/create-market.md
@@ -1,0 +1,61 @@
+---
+id: create-market
+title: Create a Market
+sidebar_label: 2. Create a Market
+sidebar_position: 3
+description: How to deploy an OctoGear lending market — pool parameters, interest rate model, and loss policy.
+---
+
+# Create a Market
+
+A **Market** consists of a liquidity pool and the risk rules that govern it. Lenders deposit into the pool; borrowers draw liquidity through attached strategies (credit managers).
+
+## Prerequisites
+
+Before creating a market, the underlying asset (the token lenders will deposit) must be whitelisted in the **Price Feed Store** for the target chain. Check the Price Feed Store in the curation interface — if your token is missing, you must add a price feed first.
+
+## Market parameters
+
+### Asset and identity
+
+| Parameter | Description |
+|---|---|
+| **Pool version** | Select the latest verified version (currently v3.1) |
+| **Underlying asset** | The token lenders deposit (e.g. USDC.e) |
+| **Price feed** | Oracle feed used to value this asset |
+| **Market name** | A descriptive name for your dashboard |
+
+### Global capacity (Total Debt Limit)
+
+The maximum amount of the underlying token that can be borrowed from the entire pool. Set this higher than your immediate target TVL to avoid frequent updates.
+
+### Interest Rate Model
+
+OctoGear uses a **Two-Kink Model** to create a stable optimal utilisation zone.
+
+| Parameter | Description |
+|---|---|
+| **U1 (Optimal Low)** | Start of the target utilisation range |
+| **U2 (Optimal High)** | End of the target utilisation range |
+| **R_base** | Interest rate at 0% utilisation (minimum cost of capital) |
+| **R_slope1 / R_slope2** | Rate increase as utilisation rises to U1 and U2 |
+| **R_slope3 (Penalty)** | Sharp rate spike after U2 — forces borrowers to repay as liquidity tightens |
+
+**Strategy tip:** Target 80–85% utilisation. Set the borrow rate in this range to roughly 60–70% of the expected yield of the collateral strategies, leaving a healthy spread for borrowers while attracting lenders.
+
+**Important — the curator fee is additive.** The Interest Fee (curator and DAO revenue) is charged *on top* of the rate paid to lenders. If the IRM rate is 5% and your Interest Fee is 20%, borrowers pay 6% total. Account for this when calibrating the IRM.
+
+### Rate governance (Tumbler)
+
+- **Type:** Select **Tumbler** — allows the curator to manually update collateral-specific rates.
+- **Epoch length:** The mandatory waiting period between rate updates (e.g. 2 days = rates can only change every 48 hours, giving borrowers predictability).
+
+### Loss policy
+
+Defines how the protocol handles bad debt (positions insolvent even after liquidation).
+
+- **Policy type:** Select **Aliased**. During extreme market events (e.g. a collateral flash crash), the system can switch to a fundamental price (e.g. exchange rate) to prevent fire-sale liquidations and pause them until the market stabilises.
+
+## Next steps
+
+The liquidity pool is now deployed. Users cannot borrow yet because no **strategies** (credit managers) are attached. Continue to [Add Strategies](./add-strategies).

--- a/docs/OctoGear/curator/execute-onchain.md
+++ b/docs/OctoGear/curator/execute-onchain.md
@@ -1,0 +1,52 @@
+---
+id: execute-onchain
+title: Execute Transactions Onchain
+sidebar_label: 4. Execute Onchain
+sidebar_position: 5
+description: How to queue and execute OctoGear governance transactions through the 24-hour timelock.
+---
+
+# Execute Transactions Onchain
+
+This is the final step. With the market configured and parameters verified, the changes are ready to be pushed to the live blockchain.
+
+## The timelock lifecycle
+
+The protocol enforces a **24-hour timelock** on all critical changes, giving lenders and borrowers time to exit if they disagree with a parameter change. Deployment is two distinct actions:
+
+1. **Queue (Propose)** — submit the transaction to the Timelock contract. The 24-hour countdown begins.
+2. **Execute (Apply)** — after the countdown ends, submit a second transaction to apply the changes.
+
+## Steps
+
+### Step 1 — Finalize the proposal
+
+In the curation interface, navigate to your proposal (GIP) page.
+
+1. Click **Finalize GIP** — this locks the configuration and prepares the transaction data.
+2. Set the **Earliest Execution Date**: add at least a 2-hour signing buffer on top of the 24-hour timelock to give multisig signers time to collect signatures.
+
+If last-minute edits are needed, click **Reopen for Changes** and re-finalize after editing.
+
+### Step 2 — Queue the transaction
+
+The interface generates a link to the Safe App.
+
+1. Click the link to open the Safe.
+2. Sign and submit the transaction — this initiates the onchain timer.
+
+### Step 3 — Execute (after 24 hours)
+
+Once the timelock expires:
+
+1. Return to the Safe App.
+2. Sign and submit the final execution transaction.
+
+## Deployment complete
+
+The market is now live on the blockchain.
+
+- **New pools** — lenders can deposit assets.
+- **New strategies** — borrowers can open Credit Accounts.
+
+Continue to [Claim Accrued Fees](./claim-fees) to understand how curator revenue works after launch.

--- a/docs/OctoGear/curator/overview.md
+++ b/docs/OctoGear/curator/overview.md
@@ -1,0 +1,72 @@
+---
+id: curator-overview
+title: What is an OctoGear Curator?
+sidebar_label: Overview
+sidebar_position: 1
+description: How OctoGear curators work — risk parameter management, roles, the timelock, and economic model.
+---
+
+# What is an OctoGear Curator?
+
+An **OctoGear Curator** is the operator of a specific lending market built on top of the OctoGear credit infrastructure (Gearbox V3). Curators act as **risk parameter managers**, not capital allocators — they define the rules under which borrowers and lenders interact, without ever having custody of user funds.
+
+This role is permissionless: any entity can deploy a Market Configurator and launch a lending business on OctoGear.
+
+## Parameters, not funds
+
+The Curator does not touch depositor funds. Instead, they manage a set of smart contracts that enforce rules on how funds can be utilised:
+
+- **No custody** — Curators cannot withdraw LP funds or seize borrower collateral.
+- **No active allocation** — Curators set eligibility rules (e.g. "Strategy A is allowed up to $10M debt"). The protocol handles the flow based on user demand.
+
+## Role architecture
+
+Curator powers are split across distinct roles to balance agility with security.
+
+### Administrator
+
+The ultimate authority, controlling the **Market Configurator** contract.
+
+- Can modify all risk parameters (LTVs, supply caps, interest models, fee splits).
+- All actions are subject to a mandatory **24-hour timelock**.
+- Recommended: a multisig safe.
+
+### Emergency Admin
+
+A crisis-response role with a limited subset of powers that bypass the timelock.
+
+- Can pause contracts, set debt limits to zero, and forbid specific adapters or tokens.
+- Cannot *increase* risk — can only restrict operations.
+- Recommended: a separate security multisig or hardware wallet.
+
+### Operational roles
+
+- **Pausable/Unpausable Admin** — freeze or unfreeze specific market contracts.
+- **Fee Collector** — designated recipient for accrued interest and liquidation fees.
+- **Emergency Liquidator** — whitelisted address permitted to liquidate when the market is paused.
+
+## The timelock
+
+Any transaction that alters a risk parameter must be queued in the Timelock contract for a minimum of **24 hours** before execution. This gives lenders and borrowers time to audit pending changes and exit if they disagree.
+
+## Economic model
+
+Curators earn revenue by configuring fee parameters that are deducted automatically by the smart contracts.
+
+| Revenue source | Description |
+|---|---|
+| Interest fee | A percentage of borrower interest, added on top of the base rate paid to lenders |
+| Liquidation fee | A percentage of collateral seized during a liquidation |
+
+**Default split:** 50% to the Curator / 50% to the Protocol DAO.
+
+## Curator vs. active capital allocator
+
+OctoGear curators are fundamentally different from vault managers on protocols like Morpho:
+
+| Action | OctoGear Curator | Active allocator (e.g. Morpho) |
+|---|---|---|
+| Add collateral exposure | Set LTV and oracle for the token — borrowers use pool liquidity | Deposit vault funds into a new market |
+| Modify LTV | Ramp LT to target value over ≥2 days | Deploy a new market; migrate liquidity |
+| Adjust collateral-specific rate | Set a new quota rate on top of the IRM | Move allocation in/out of the market |
+| Enable leverage for a collateral | Allow the relevant adapters in the strategy | Integrate with an external strategy provider |

--- a/docs/OctoGear/guides/create-account.md
+++ b/docs/OctoGear/guides/create-account.md
@@ -16,7 +16,7 @@ A passkey uses your device's biometrics — Touch ID, Face ID, or Windows Hello 
 
 ### Steps
 
-1. Go to [octogear.finance](https://octogear.finance) and click **Connect**
+1. Go to [octogear.untangled.finance](https://octogear.untangled.finance) and click **Connect**
 2. Select **Passkey** from the sign-in options
 3. Your browser prompts you to register (new user) or sign in (returning user) with your device biometric
 4. Your Prime Account is created — you now have a NEAR identity and a derived Polygon address

--- a/docs/OctoGear/intro.md
+++ b/docs/OctoGear/intro.md
@@ -55,4 +55,6 @@ The Prime Account is built for autonomous agents. Session keys and the OctoGear 
 
 ## Current state
 
-OctoGear is live on **Polygon mainnet** (Pool Alpha, USDC.e) and **HyperEVM** via Hyperliquid. The codebase is pre-audit — use small amounts until you are comfortable with the mechanics. See [Risk Disclosures](./reference/risk-disclosure) before depositing.
+OctoGear is live on **Polygon mainnet** (Pool Alpha, USDC.e) and **HyperEVM** via Hyperliquid.
+
+The core credit infrastructure is built on **Gearbox V3**, which has been independently audited and battle-tested in production. OctoGear's own **adapters and registries** — the smart contracts that connect Gearbox credit accounts to Polymarket and Hyperliquid — are pre-audit. Use small amounts until you are comfortable with the mechanics and the adapter audit is complete. See [Risk Disclosures](./reference/risk-disclosure) before depositing.

--- a/docs/OctoGear/reference/risk-disclosure.md
+++ b/docs/OctoGear/reference/risk-disclosure.md
@@ -8,7 +8,7 @@ description: Risk disclosures for using OctoGear — smart contract risk, levera
 
 # Risk Disclosures
 
-OctoGear is a non-custodial, pre-audit protocol. Read these disclosures before depositing or trading.
+OctoGear is a non-custodial protocol. The core credit infrastructure runs on Gearbox V3, which has been independently audited and battle-tested in production. OctoGear's own adapters — the contracts that connect Gearbox credit accounts to Polymarket and Hyperliquid — are pre-audit. Read these disclosures before depositing or trading.
 
 ## Non-custodial — you hold the keys
 
@@ -26,7 +26,7 @@ Prediction market collateral has a binary payoff. A YES position that resolves N
 
 ## Smart contract risk
 
-OctoGear's adapters and registries are pre-audit. Gearbox V3 has been audited independently; OctoGear's extensions have not. Bugs, exploits, and unexpected contract behaviour can result in partial or total loss of deposited funds. Use amounts you are prepared to lose entirely while the audit is in progress.
+OctoGear's credit infrastructure runs on **Gearbox V3**, which has been independently audited. OctoGear's own **adapters and registries** — the contracts that route interactions to Polymarket and Hyperliquid — are pre-audit. Bugs, exploits, or unexpected behaviour in the adapters can result in partial or total loss of deposited funds. Use amounts you are prepared to lose entirely while the adapter audit is in progress.
 
 ## Liquidation is autonomous
 


### PR DESCRIPTION
…ates

- Clarify in intro and risk-disclosure that Gearbox V3 core is audited; only OctoGear adapters are pre-audit
- Fix OctoGear UI URL to octogear.untangled.finance in create-account guide
- Add curator guide section (overview, create configurator, create market, add strategies, execute onchain, claim fees) adapted from Gearbox flow
- Add OctoGear section and cards to the welcome-to-untangled landing page