### PR TITLE
docs(octogear): verify curator guide against deployed contracts

### DIFF
--- a/docs/OctoGear/curator/add-strategies.md
+++ b/docs/OctoGear/curator/add-strategies.md
@@ -16,13 +16,30 @@ Examples:
 
 You can attach multiple strategies to a single pool to segment risk and offer different terms for different borrower profiles.
 
+## OctoGear adapter architecture
+
+Before configuring strategies, understand how OctoGear's adapters work together:
+
+| Adapter | Role |
+|---|---|
+| **PolymarketAdapter** | Whitelisted adapter for Polymarket CTF custody — routes buy/sell orders through the CTFExchangeV2 |
+| **PUSDOnrampAdapter** | Wraps USDC.e → pUSD (Polymarket's USDC wrapper) before placing orders |
+| **PUSDOfframpAdapter** | Unwraps pUSD → USDC.e after closing positions |
+| **PUSDTransferAdapter** | Transfers pUSD to a credit account's `SmartMaker` contract |
+
+Polymarket outcome tokens (YES/NO) are **not** held directly in the credit account. Each account gets a dedicated `SmartMaker` custody contract (tracked by the `SmartMakerRegistry`) that holds the CTF ERC-1155 tokens. The credit account's collateral value is computed from the SmartMaker's CTF holdings via price feeds set in `PriceOracleV3`.
+
+**Before enabling a prediction market as collateral**, confirm with the OctoGear team that:
+1. The market is whitelisted in the `MarketRegistry`
+2. Price feeds for its YES and NO phantom tokens exist in `PriceOracleV3`
+
 ## How to add a strategy
 
 ### Step 1 — Select a strategy bundle
 
-In the curation interface, open the **New Strategy** tab and search for the collateral token you want to support (e.g. cUSDC, YES tokens). Strategy bundles are pre-configured recipes — selecting one automatically configures the smart contract adapters needed to enable leverage for that asset.
+In the curation interface, open the **New Strategy** tab and search for the collateral token you want to support. Strategy bundles are pre-configured recipes that automatically wire the necessary adapters (PolymarketAdapter, PUSD adapters) for that asset.
 
-If no bundle exists for your target token, contact the OctoGear team to request one.
+If no bundle exists for your target token, contact the OctoGear team to request one — adapter deployment and MarketRegistry whitelisting must happen before a bundle can be created.
 
 ### Step 2 — Set leverage parameters
 

--- a/docs/OctoGear/curator/overview.md
+++ b/docs/OctoGear/curator/overview.md
@@ -19,6 +19,17 @@ The Curator does not touch depositor funds. Instead, they manage a set of smart 
 - **No custody** — Curators cannot withdraw LP funds or seize borrower collateral.
 - **No active allocation** — Curators set eligibility rules (e.g. "Strategy A is allowed up to $10M debt"). The protocol handles the flow based on user demand.
 
+## OctoGear-specific infrastructure
+
+Beyond standard Gearbox V3, OctoGear adds two contracts curators must understand:
+
+| Contract | Role |
+|---|---|
+| **MarketRegistry** | Whitelist of allowed prediction markets, lockdown state, and resolution tracking. A prediction market outcome token cannot be used as credit account collateral unless it is whitelisted here by the OctoGear team. |
+| **SmartMakerRegistry** | Deploys and tracks per-credit-account CTF custody contracts. Polymarket positions are not held directly in a credit account — each account gets a dedicated `SmartMaker` contract that holds CTF tokens on its behalf. |
+
+Curators do not directly control these registries. The OctoGear team manages market whitelisting and SmartMaker deployment. When configuring collateral for a new prediction market, confirm the market is already registered before setting its liquidation threshold.
+
 ## Role architecture
 
 Curator powers are split across distinct roles to balance agility with security.


### PR DESCRIPTION
Add MarketRegistry and SmartMakerRegistry context to curator docs:
- overview: explain that PM markets must be whitelisted in MarketRegistry before use as collateral; describe SmartMaker per-account CTF custody
- add-strategies: document the full adapter set (Polymarket, PUSD onramp/ offramp/transfer) and SmartMakerRegistry collateral flow; gate checklist before enabling a new market as collateral